### PR TITLE
please merge and squash commits

### DIFF
--- a/.github/workflows/quickstart_ejb-timer_ci.yml
+++ b/.github/workflows/quickstart_ejb-timer_ci.yml
@@ -1,16 +1,15 @@
-name: WildFly EJB Timer Quickstart CI
+name: WildFly ejb-timer Quickstart CI
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - <quickstart-path>/ejb-timer/**'
-      - .github/workflows/quickstart_ci.yml
+      - '<quickstart-path>/ejb-timer/**'
+      - '.github/workflows/quickstart_ci.yml'
 
 jobs:
   call-quickstart_ci:
     uses: ./.github/workflows/quickstart_ci.yml
     with:
       QUICKSTART_PATH: ejb-timer
-      DEPLOYMENT_DIR: webapp
       TEST_PROVISIONED_SERVER: true

--- a/ejb-timer/README.adoc
+++ b/ejb-timer/README.adoc
@@ -21,12 +21,6 @@ The following Jakarta Enterprise Bean Timer services are demonstrated:
 * `@Schedule`: Uses this annotation to mark a method to be executed according to the calendar schedule specified in the attributes of the annotation. This example schedules a message to be printed to the server console every 6 seconds.
 * `@Timeout`: Uses this annotation to mark a method to execute when a programmatic timer goes off. This example sets the timer to go off every 3 seconds, at which point the method prints a message to the server console.
 
-//*************************************************
-// Product Release content only
-//*************************************************
-
-ifndef::EAPCDRelease[]
-
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}
@@ -35,8 +29,6 @@ include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 // Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-// Undeploy the Quickstart
-include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
 
@@ -88,12 +80,17 @@ INFO  [stdout] (EJB default - 1) Timeout received for TimeoutExample[-1065503193
 INFO  [stdout] (EJB default - 2) Timeout received for TimeoutExample[-1065503193] at 2022-05-04T21:19:06.002358Z
 ----
 
+// Server Distribution Testing
+include::../shared-doc/run-integration-tests-with-server-distribution.adoc[leveloffset=+2]
+
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
-include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-// Debug the Application
-include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+// Build and run sections for other environments/builds
+ifndef::ProductRelease,EAPXPRelease[]
+include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
+endif::[]
+include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
 
 === Using Timer Service within a cluster
 
@@ -169,14 +166,3 @@ If you then shutdown the node on which the ScheduleExample timeouts appear (in o
 
 Restarting the node that we previously shutdown (in our case, node2), using the same command as listed above), you should observe that timeouts for the ScheduleExample timer will resume on the original node (in our case, node2), and now the other node (in our case, node1) no longer receives those timeout events.
 In fact, if you collate the timestamps for the ScheduleExample bean across each server log carefully, you should find that no events were skipped, and no duplicate events were received.
-
-endif::[]
-
-//*************************************************
-// Product Release content only
-//*************************************************
-// Build and run sections for other environments/builds
-ifndef::ProductRelease,EAPXPRelease[]
-include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
-endif::[]
-include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]


### PR DESCRIPTION
Issues fixed: 
* CI yml file was on ejb-timer/.github/... when it should be on /.github/...
* minor issues in CI yml content (name, missing some ', no need for DEPLOYMENT_DIR param)
* added README.adoc's standard dist testing section include, after the section wrt accessing the app 
* removed README.adoc's undeploy section include dupe
* moved up server provisioning and openshift section includes, for content to be rended before the clustering final experience
* cleaned README.adoc's deprecated content (didn't ask for this, usually do that later)
